### PR TITLE
Improvements for HTTP CGI server

### DIFF
--- a/cgi_server.py
+++ b/cgi_server.py
@@ -8,8 +8,12 @@ from subprocess import call
 
 # Edit these values to control the server behavior
 PORT    = 7000
-COMMAND = "sleep"
-ARGS    = "3"
+COMMAND = "java"
+ARGS    = ["-jar",
+           "nihms-cli-1.0.0-SNAPSHOT-shaded.jar",
+           "/usr/local/src/huims-submission/nihms-cli/src/main/resources/FilesystemModelBuilderTest.properties",
+           "local"
+          ]
 
 
 # Define a request handler class that runs a command when it receives a POST
@@ -20,16 +24,23 @@ class RequestHandler (BaseHTTPServer.BaseHTTPRequestHandler):
         # Execute the command and prepare the POST response code.
         # Prints an error message to the console on failure.
         # This is a blocking function.  Use subprocess.Popen for non-blocking.
-        status = call([COMMAND, ARGS])
-        if status != 0:
-            print "Command '{} {}' failed with code {}".format(COMMAND, ARGS, status)
+        try:
+            status = call([COMMAND]+list(ARGS))
+            if status != 0:
+                args = " ".join(str(x) for x in ARGS)
+                print "Command '{} {}' failed with code {}".format(COMMAND, args, status)
+                code = 500
+            else:
+                code = 200
+        except:
+            args = " ".join(str(x) for x in ARGS)
+            print "Command '{} {}' failed with an exception".format(COMMAND, args)
             code = 500
-        else:
-            code = 200
 
         # Prepare and send the response header
         s.send_response(code)
         s.send_header("Content-type", "text/html")
+        s.send_header("Access-Control-Allow-Origin", "*")
         s.end_headers()
 
 # Create and run the server


### PR DESCRIPTION
This submission makes the following changes to the PASS HTTP CGI server:
* The response header allows all callers to receive responses.  This
relates to the pass-ember submission for issue 54.
* Exceptions resulting from the execution of the server's command are
now caught and returned as cod 500.
* The arguments specifcation mechanism how allows an array of arguments
to be specified, passed to the command and printed in case of error.
The default command is now the one given to me by Elliot on 12/11/17.