### PR TITLE
Support environment variables for configuring the CGI script

### DIFF
--- a/cgi_server.py
+++ b/cgi_server.py
@@ -14,8 +14,8 @@ FTP_CONFIGURATION_KEY = os.getenv('FTP_CONFIGURATION_KEY', "local")
 COMMAND = "java"
 ARGS    = ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + DEBUG_PORT,
            "-jar",
-           "nihms-cli-1.0.0-SNAPSHOT-shaded.jar",
-           "/usr/local/src/huims-submission/nihms-cli/src/main/resources/FilesystemModelBuilderTest.properties",
+           "/usr/local/src/nihms-submission/nihms-cli/target/nihms-cli-1.0.0-SNAPSHOT-shaded.jar",
+           "/usr/local/src/nihms-submission/nihms-cli/src/main/resources/FilesystemModelBuilderTest.properties",
            FTP_CONFIGURATION_KEY
           ]
 

--- a/cgi_server.py
+++ b/cgi_server.py
@@ -3,16 +3,20 @@
 # A simple HTTP server that responds to POSTs by running a shell command
 # Usage: python cgi_server.py &
 
+import os
 import BaseHTTPServer
 from subprocess import call
 
 # Edit these values to control the server behavior
-PORT    = 7000
+PORT = int(os.getenv('PY_CGI_PORT', "8080"))
+DEBUG_PORT = os.getenv('FTP_SUBMISSION_DEBUG_PORT', "5005")
+FTP_CONFIGURATION_KEY = os.getenv('FTP_CONFIGURATION_KEY', "local")
 COMMAND = "java"
-ARGS    = ["-jar",
+ARGS    = ["-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=" + DEBUG_PORT,
+           "-jar",
            "nihms-cli-1.0.0-SNAPSHOT-shaded.jar",
            "/usr/local/src/huims-submission/nihms-cli/src/main/resources/FilesystemModelBuilderTest.properties",
-           "local"
+           FTP_CONFIGURATION_KEY
           ]
 
 


### PR DESCRIPTION
* Enables Java debugging on the FTP submission
* Corrects a couple typos
* Supports the following environment variables
    - `PY_CGI_PORT` (default `8080`)
    - `FTP_SUBMISSION_DEBUG_PORT` (default `5005`)
    - `FTP_CONFIGURATION_KEY` (default `local`)

(**Note:** should be _squashed_ when merging)